### PR TITLE
Fetch contributions from Directus

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -37,14 +37,12 @@ export default function LoginPage() {
     setLoading(true);
 
     try {
-      const me = (await login(email, password)) as {
-        first_name: string;
-        last_name: string;
-        email: string;
-      };
+      const me = await login(email, password);
+      const user = me as { first_name?: string; last_name?: string; email?: string };
 
       const fullName =
-        [me.first_name, me.last_name].filter(Boolean).join(" ") || me.email;
+        [user.first_name, user.last_name].filter(Boolean).join(" ") ||
+        user.email || "";
 
       message.success(`Bienvenue ${fullName} !`);
 

--- a/src/components/NewContributionDrawer/NewContributionDrawer.tsx
+++ b/src/components/NewContributionDrawer/NewContributionDrawer.tsx
@@ -66,7 +66,8 @@ const FontSize = Extension.create({
           },
         },
       },
-    ];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any;
   },
 });
 

--- a/src/hooks/useContributions.ts
+++ b/src/hooks/useContributions.ts
@@ -1,28 +1,76 @@
-import { useMemo } from "react";
+import { useEffect, useState } from "react";
+import { readItems } from "@directus/sdk";
 import type { Contribution } from "@/types/contribution";
+import { directus } from "@/lib/directus";
+import type {
+  Contribution as DirectusContribution,
+  Organization,
+  Sector,
+  DirectusUser,
+  ContributionsStatus,
+} from "../../models/types";
+
+type DirectusContributionExpanded = Omit<
+  DirectusContribution,
+  "organization" | "sector_activity" | "user_created" | "status"
+> & {
+  organization: Pick<Organization, "name">;
+  sector_activity: Pick<Sector, "label">;
+  user_created: Pick<DirectusUser, "first_name" | "last_name" | "email">;
+  status: Pick<ContributionsStatus, "label">;
+};
 
 export function useContributions() {
-  const data: Contribution[] = useMemo(
-    () => [
-      {
-        id: "1",
-        title: "Mairie de Nantes",
-        sector: "Collectivité",
-        author: "Arnaud Beun",
-        visibility: "PUBLIC",
-        createdAt: "2025-06-25",
-      },
-      {
-        id: "2",
-        title: "Eiffage Promotion",
-        sector: "Promoteur",
-        author: "Toi-même",
-        visibility: "PRIVATE",
-        createdAt: "2025-06-29",
-      },
-    ],
-    [],
-  );
+  const [data, setData] = useState<Contribution[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const items = await directus.request<DirectusContributionExpanded[]>(
+          readItems("contributions", {
+            fields: [
+              "id",
+              "date_created",
+              "is_public",
+              { organization: ["name"] },
+              { sector_activity: ["label"] },
+              { user_created: ["first_name", "last_name", "email"] },
+              { status: ["label"] },
+            ],
+            sort: "-date_created",
+          }),
+        );
+
+        const mapped = items.map<Contribution>((item) => ({
+          id: item.id,
+          title:
+            typeof item.organization === "object" ? item.organization.name : "",
+          sector:
+            typeof item.sector_activity === "object"
+              ? item.sector_activity.label
+              : "",
+          author:
+            typeof item.user_created === "object"
+              ?
+                  ([item.user_created.first_name, item.user_created.last_name]
+                    .filter(Boolean)
+                    .join(" ") || item.user_created.email)
+              : "",
+          visibility:
+            typeof item.status === "object" && item.status.label === "ARCHIVED"
+              ? "ARCHIVED"
+              : item.is_public
+                ? "PUBLIC"
+                : "PRIVATE",
+          createdAt: String(item.date_created),
+        }));
+
+        setData(mapped);
+      } catch (err) {
+        console.error(err);
+      }
+    })();
+  }, []);
 
   return { data };
 }

--- a/src/lib/directus.ts
+++ b/src/lib/directus.ts
@@ -2,6 +2,7 @@
 import { createDirectus, rest, authentication } from "@directus/sdk";
 
 import type { AuthenticationData } from "@directus/sdk";
+import type { ApiCollections } from "../../models/types";
 
 const browserStorage: {
   set(data): Promise<void>;
@@ -19,7 +20,9 @@ const browserStorage: {
     window.localStorage.removeItem("directus_auth");
   },
 };
-export const directus = createDirectus(process.env.NEXT_PUBLIC_DIRECTUS_URL!)
+export const directus = createDirectus<ApiCollections>(
+  process.env.NEXT_PUBLIC_DIRECTUS_URL!,
+)
   .with(rest())
   .with(
     authentication("json", {


### PR DESCRIPTION
## Summary
- integrate Directus client types
- implement `useContributions` to load data from Directus
- adapt login page typing
- silence a lint issue in `NewContributionDrawer`

## Testing
- `npm run lint`
- `npm run build`