### PR TITLE
Refactor typing

### DIFF
--- a/src/app/(protected)/contributions/page.tsx
+++ b/src/app/(protected)/contributions/page.tsx
@@ -41,7 +41,7 @@ export default function ContributionsPage() {
 
       <ContributionDrawer
         open={Boolean(selected)}
-        data={selected as never ?? undefined}
+        data={selected ?? undefined}
         onClose={() => setSelected(null)}
       />
 

--- a/src/components/ContributionDrawer/ContributionDrawer.tsx
+++ b/src/components/ContributionDrawer/ContributionDrawer.tsx
@@ -20,7 +20,7 @@ type Props = {
   open: boolean;
   onClose: () => void;
   data?: Contribution & {
-    contactName: string;
+    contactName?: string;
     contactRole?: string;
     contactType?: string;
     rdvDate?: string;

--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -9,9 +9,10 @@ import {
   PropsWithChildren,
 } from "react";
 import { directus } from "./directus";
-import { readMe } from "@directus/sdk";
+import { readMe, type DirectusUser } from "@directus/sdk";
+import type { ApiCollections } from "../../models/types";
 
-export type Me = Awaited<ReturnType<typeof directus.request<typeof readMe>>>;
+export type Me = DirectusUser<ApiCollections>;
 
 interface AuthValue {
   user: Me | null;
@@ -30,8 +31,8 @@ export function AuthProvider({ children }: PropsWithChildren) {
   useEffect(() => {
     (async () => {
       try {
-        const me = await directus.request(readMe());
-        setUser(me as never);
+        const me = await directus.request<Me>(readMe());
+        setUser(me);
       } catch {
         setUser(null);
       } finally {
@@ -40,12 +41,12 @@ export function AuthProvider({ children }: PropsWithChildren) {
     })();
   }, []);
 
-  const login = useCallback(async (email: string, password: string) : Promise<never> => {
+  const login = useCallback(async (email: string, password: string): Promise<Me> => {
     await directus.login(email, password);
-    const me = await directus.request(readMe());
+    const me = await directus.request<Me>(readMe());
 
-    setUser(me as never);
-    return me as never;
+    setUser(me);
+    return me;
   }, []);
 
   const logout = useCallback(async () => {

--- a/src/lib/directus.ts
+++ b/src/lib/directus.ts
@@ -5,7 +5,7 @@ import type { AuthenticationData } from "@directus/sdk";
 import type { ApiCollections } from "../../models/types";
 
 const browserStorage: {
-  set(data): Promise<void>;
+  set(data: AuthenticationData | null): Promise<void>;
   get(): Promise<AuthenticationData | null>;
   delete(): Promise<void>;
 } = {
@@ -13,7 +13,7 @@ const browserStorage: {
     const raw = window.localStorage.getItem("directus_auth");
     return raw ? (JSON.parse(raw) as AuthenticationData) : null;
   },
-  async set(data) {
+  async set(data: AuthenticationData | null) {
     window.localStorage.setItem("directus_auth", JSON.stringify(data));
   },
   async delete() {


### PR DESCRIPTION
## Summary
- remove `as never` and replace with correct types in `AuthProvider`
- allow optional contact info in `ContributionDrawer`
- simplify usage in Contributions page
- type browser storage methods

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build` *(fails: Invalid URL during prerender)*