### PR TITLE
Improve contribution drawer and filters

### DIFF
--- a/src/app/(protected)/contributions/page.tsx
+++ b/src/app/(protected)/contributions/page.tsx
@@ -7,6 +7,9 @@ import styles from "./ContributionsPage.module.scss";
 
 import ContributionTabs from "@/components/ContributionTabs/ContributionTabs";
 import ContributionsList from "@/components/ContributionList/ContributionList";
+import ContributionsFilters, {
+  type Filters,
+} from "@/components/ContributionsFilters/ContributionsFilters";
 import ContributionDrawer from "@/components/ContributionDrawer/ContributionDrawer";
 import { PageHeader } from "@/components/PageHeader/PageHeader";
 import type { Contribution } from "@/types/contribution";
@@ -16,6 +19,8 @@ export default function ContributionsPage() {
   const [activeTab, setActiveTab] = useState<"all" | "mine" | "public">("all");
   const [selected, setSelected] = useState<Contribution | null>(null);
   const [formOpen, setFormOpen] = useState(false);
+  const [filters, setFilters] = useState<Filters>({});
+  const [page, setPage] = useState(1);
 
   return (
     <div className={styles.container}>
@@ -27,12 +32,19 @@ export default function ContributionsPage() {
       <div className={styles.content}>
         <ContributionTabs
           activeTab={activeTab}
-          onChangeTab={setActiveTab}
+          onChangeTab={(tab) => { setPage(1); setActiveTab(tab); }}
           onCreate={() => setFormOpen(true)}
         />
 
+        <ContributionsFilters value={filters} onChange={(f) => { setPage(1); setFilters(f); }} />
         <div className={styles.listWrapper}>
-          <ContributionsList tab={activeTab} onSelect={setSelected} />
+          <ContributionsList
+            tab={activeTab}
+            filters={filters}
+            page={page}
+            onPageChange={setPage}
+            onSelect={setSelected}
+          />
         </div>
 
         <FloatButton

--- a/src/components/ContributionList/ContributionList.tsx
+++ b/src/components/ContributionList/ContributionList.tsx
@@ -3,26 +3,31 @@
 import { List } from "antd";
 import { useContributions } from "@/hooks/useContributions";
 import type { Contribution } from "@/types/contribution";
+import type { Filters } from "@/components/ContributionsFilters/ContributionsFilters";
 
 import ContributionCard from "@/components/ContributionCard/ContributionCard";
-import { useEffect } from "react";
 
 type Props = {
   tab: "all" | "mine" | "public";
+  filters: Filters;
+  page: number;
+  onPageChange: (page: number) => void;
   onSelect: (item: Contribution) => void;
 };
 
-export default function ContributionsList({ tab, onSelect }: Props) {
-  const { data, isLoading } = useContributions(tab);
+export default function ContributionsList({ tab, filters, page, onPageChange, onSelect }: Props) {
+  const { data } = useContributions(tab, { ...filters, page });
 
-  useEffect(() => {
-    console.log(data);
-    console.log(isLoading);
-  }, [data, isLoading]);
   return (
     <List
       grid={{ gutter: 16, column: 1 }}
       dataSource={data}
+      pagination={{
+        pageSize: 10,
+        current: page,
+        onChange: onPageChange,
+        hideOnSinglePage: true,
+      }}
       renderItem={(item) => (
         <ContributionCard
           key={item.id}

--- a/src/components/ContributionsFilters/ContributionsFilters.module.scss
+++ b/src/components/ContributionsFilters/ContributionsFilters.module.scss
@@ -1,0 +1,3 @@
+.wrapper {
+  margin-bottom: 1rem;
+}

--- a/src/components/ContributionsFilters/ContributionsFilters.tsx
+++ b/src/components/ContributionsFilters/ContributionsFilters.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Input, Select, Space } from "antd";
+import styles from "./ContributionsFilters.module.scss";
+
+const sectors = [
+  "Promoteur",
+  "Constructeur",
+  "Architecte",
+  "Collectivités",
+  "Entreprises",
+  "Services",
+  "Autre",
+];
+
+export type Filters = {
+  search?: string;
+  sector?: string;
+  visibility?: string;
+};
+
+export default function ContributionsFilters({
+  value,
+  onChange,
+}: {
+  value: Filters;
+  onChange: (val: Filters) => void;
+}) {
+  return (
+    <Space className={styles.wrapper} wrap size="middle">
+      <Input.Search
+        allowClear
+        placeholder="Rechercher…"
+        value={value.search}
+        onChange={(e) => onChange({ ...value, search: e.target.value })}
+        style={{ maxWidth: 200 }}
+      />
+      <Select
+        allowClear
+        placeholder="Secteur"
+        value={value.sector}
+        onChange={(val) => onChange({ ...value, sector: val })}
+        options={sectors.map((s) => ({ value: s, label: s }))}
+        style={{ width: 160 }}
+      />
+      <Select
+        allowClear
+        placeholder="Visibilité"
+        value={value.visibility}
+        onChange={(val) => onChange({ ...value, visibility: val })}
+        options={[
+          { value: "PUBLIC", label: "Publique" },
+          { value: "PRIVATE", label: "Privée" },
+          { value: "ARCHIVED", label: "Archivée" },
+        ]}
+        style={{ width: 160 }}
+      />
+    </Space>
+  );
+}

--- a/src/components/NewContributionDrawer/NewContributionDrawer.module.scss
+++ b/src/components/NewContributionDrawer/NewContributionDrawer.module.scss
@@ -13,6 +13,11 @@
   height: 100%;
   padding: 24px clamp(16px, 4vw, 64px);
   gap: 24px;
+  background-color: #fafafa;
+}
+
+.steps {
+  padding-bottom: 1rem;
 }
 
 /* ───────── Zone scrollable ───────── */


### PR DESCRIPTION
## Summary
- enhance creation drawer navigation and add cancel option
- add search and filtering controls for contributions
- support pagination in contribution list
- expose filtering capabilities in `useContributions`
- tweak drawer styling for a cleaner SaaS look

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687f4d16e440832c9b044ce21e208d8b