### PR TITLE
Extend contribution creation with contact details

### DIFF
--- a/src/components/NewContributionDrawer/NewContributionDrawer.tsx
+++ b/src/components/NewContributionDrawer/NewContributionDrawer.tsx
@@ -9,6 +9,7 @@ import {
   Space,
   Divider,
   App,
+  Input,
 } from "antd";
 import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
@@ -28,20 +29,13 @@ import OrganizationSelector, {
   type OrganizationValue,
 } from "@/components/OrganizationSelector/OrganizationSelector";
 import { useCreateContribution } from "@/hooks/useCreateContribution";
+import { useSectors } from "@/hooks/useSectors";
+import { useOrigins } from "@/hooks/useOrigins";
+import { useContactQualifs } from "@/hooks/useContactQualifs";
+import { useProjectQualifs } from "@/hooks/useProjectQualifs";
 
 const { Step } = Steps;
 
-/* ────────────────────────────────────────────────────────── */
-/* Données fixes                                             */
-const sectors = [
-  "Promoteur",
-  "Constructeur",
-  "Architecte",
-  "Collectivités",
-  "Entreprises",
-  "Services",
-  "Autre",
-];
 
 type Props = {
   open: boolean;
@@ -89,6 +83,10 @@ export default function NewContributionDrawer({
   const [organization, setOrganization] = useState<OrganizationValue>();
   const { message } = App.useApp();
   const createMutation = useCreateContribution();
+  const { data: sectors = [] } = useSectors();
+  const { data: origins = [] } = useOrigins();
+  const { data: contactQualifs = [] } = useContactQualifs();
+  const { data: projectQualifs = [] } = useProjectQualifs();
 
   /* ────── TIPTAP EDITOR ────── */
   const editor = useEditor({
@@ -160,10 +158,17 @@ export default function NewContributionDrawer({
       organization: organization.id,
       organizationName: organization.name,
       sector: values.sector,
-      contactType: values.contactType,
-      qualification: values.qualification,
+      contactOrigin: values.contactOrigin,
+      contactQualification: values.contactQualification,
+      projectQualification: values.projectQualification,
       visibility: values.visibility,
       summary: editor?.getHTML() || "",
+      firstName: values.firstName,
+      lastName: values.lastName,
+      position: values.position,
+      email: values.email,
+      phone: values.phone,
+      region: values.region,
     });
 
     onSubmit?.({
@@ -228,38 +233,106 @@ export default function NewContributionDrawer({
                   />
                 </Form.Item>
 
-                  <Space direction="horizontal" size="large" wrap>
-                    <Form.Item
-                      preserve={false}
-                      label="Secteur d’activité"
-                      name="sector"
-                      rules={[{ required: true }]}
-                    >
-                      <Select
-                        placeholder="Choisir…"
-                        options={sectors.map((s) => ({ value: s, label: s }))}
-                        style={{ minWidth: 200 }}
-                      />
-                    </Form.Item>
+                <Space direction="horizontal" size="large" wrap>
+                  <Form.Item
+                    preserve={false}
+                    label="Secteur d’activité"
+                    name="sector"
+                    rules={[{ required: true }]}
+                  >
+                    <Select
+                      placeholder="Choisir…"
+                      options={sectors.map((s) => ({ value: s.id, label: s.label }))}
+                      style={{ minWidth: 200 }}
+                    />
+                  </Form.Item>
 
-                    <Form.Item
-                      preserve={false}
-                      label="Type de contact"
-                      name="contactType"
-                      rules={[{ required: true }]}
-                    >
-                      <Select
-                        placeholder="Prospect, Client…"
-                        options={[
-                          "Prospect",
-                          "Client",
-                          "Partenaire",
-                          "Informateur",
-                        ].map((t) => ({ value: t, label: t }))}
-                        style={{ minWidth: 200 }}
-                      />
-                </Form.Item>
-              </Space>
+                  <Form.Item
+                    preserve={false}
+                    label="Origine du contact"
+                    name="contactOrigin"
+                    rules={[{ required: true }]}
+                  >
+                    <Select
+                      placeholder="Prospect, Client…"
+                      options={origins.map((o) => ({ value: o.id, label: o.label }))}
+                      style={{ minWidth: 200 }}
+                    />
+                  </Form.Item>
+                </Space>
+
+                <Space direction="horizontal" size="large" wrap>
+                  <Form.Item
+                    preserve={false}
+                    label="Prénom"
+                    name="firstName"
+                    rules={[{ required: true }]}
+                  >
+                    <Input style={{ minWidth: 160 }} />
+                  </Form.Item>
+
+                  <Form.Item
+                    preserve={false}
+                    label="Nom"
+                    name="lastName"
+                    rules={[{ required: true }]}
+                  >
+                    <Input style={{ minWidth: 160 }} />
+                  </Form.Item>
+                </Space>
+
+                <Space direction="horizontal" size="large" wrap>
+                  <Form.Item
+                    preserve={false}
+                    label="Fonction"
+                    name="position"
+                    rules={[{ required: true }]}
+                  >
+                    <Input style={{ minWidth: 160 }} />
+                  </Form.Item>
+
+                  <Form.Item
+                    preserve={false}
+                    label="Qualification"
+                    name="contactQualification"
+                    rules={[{ required: true }]}
+                  >
+                    <Select
+                      placeholder="Sélectionner…"
+                      options={contactQualifs.map((q) => ({ value: q.id, label: q.label }))}
+                      style={{ minWidth: 160 }}
+                    />
+                  </Form.Item>
+                </Space>
+
+                <Space direction="horizontal" size="large" wrap>
+                  <Form.Item
+                    preserve={false}
+                    label="Email"
+                    name="email"
+                    rules={[{ required: true, type: "email" }]}
+                  >
+                    <Input style={{ minWidth: 200 }} />
+                  </Form.Item>
+
+                  <Form.Item
+                    preserve={false}
+                    label="Téléphone"
+                    name="phone"
+                    rules={[{ required: true }]}
+                  >
+                    <Input style={{ minWidth: 160 }} />
+                  </Form.Item>
+
+                  <Form.Item
+                    preserve={false}
+                    label="Région"
+                    name="region"
+                    rules={[{ required: true }]}
+                  >
+                    <Input style={{ minWidth: 120 }} />
+                  </Form.Item>
+                </Space>
               </>
             )}
 
@@ -285,16 +358,10 @@ export default function NewContributionDrawer({
                   <Form.Item
                     preserve={false}
                     label="Qualification du projet"
-                    name="qualification"
+                    name="projectQualification"
                   >
                     <Select
-                      options={[
-                        "Information",
-                        "Projet à lancer (délai inconnu)",
-                        "Projet à lancer < 6 mois",
-                        "Projet lancé",
-                        "Projet terminé",
-                      ].map((q) => ({ value: q, label: q }))}
+                      options={projectQualifs.map((q) => ({ value: q.id, label: q.label }))}
                       placeholder="Sélectionner…"
                     />
                   </Form.Item>

--- a/src/hooks/useContactQualifs.ts
+++ b/src/hooks/useContactQualifs.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { readItems } from "@directus/sdk";
+import { directus } from "@/lib/directus";
+import type { ContactQualif } from "../../models/types";
+
+export function useContactQualifs() {
+  return useQuery({
+    queryKey: ["contact_qualifs"],
+    queryFn: () =>
+      directus.request<Pick<ContactQualif, "id" | "label">[]>(
+        readItems("contact_qualifs", { fields: ["id", "label"], sort: "label" }),
+      ),
+  });
+}

--- a/src/hooks/useCreateContribution.ts
+++ b/src/hooks/useCreateContribution.ts
@@ -6,10 +6,17 @@ export type NewContributionPayload = {
   organization?: string;
   organizationName?: string;
   sector?: string;
-  contactType?: string;
-  qualification?: string;
+  contactOrigin?: string;
+  contactQualification?: string;
+  projectQualification?: string;
   visibility?: string;
   summary?: string;
+  firstName: string;
+  lastName: string;
+  position: string;
+  email: string;
+  phone: string;
+  region: string;
 };
 
 export function useCreateContribution() {
@@ -26,11 +33,29 @@ export function useCreateContribution() {
         organizationId = org.id;
       }
 
+      const contact = await directus.request<{ id: string }>(
+        createItem("contacts", {
+          organization: organizationId,
+          first_name: payload.firstName,
+          last_name: payload.lastName,
+          position: payload.position,
+          email: payload.email,
+          phone: payload.phone,
+          region: payload.region,
+          is_primary: true,
+        }),
+      );
+
       const contribution: Record<string, unknown> = {
         organization: organizationId,
+        contact: contact.id,
+        contact_function: payload.position,
+        contact_email: payload.email,
+        contact_phone: payload.phone,
         sector_activity: payload.sector,
-        contact_origin: payload.contactType,
-        project_qualification: payload.qualification,
+        contact_origin: payload.contactOrigin,
+        contact_qualification: payload.contactQualification,
+        project_qualification: payload.projectQualification,
         is_public: payload.visibility === "PUBLIC",
         notes_raw: payload.summary,
       };

--- a/src/hooks/useOrigins.ts
+++ b/src/hooks/useOrigins.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { readItems } from "@directus/sdk";
+import { directus } from "@/lib/directus";
+import type { Origin } from "../../models/types";
+
+export function useOrigins() {
+  return useQuery({
+    queryKey: ["origins"],
+    queryFn: () =>
+      directus.request<Pick<Origin, "id" | "label">[]>(
+        readItems("origins", { fields: ["id", "label"], sort: "label" }),
+      ),
+  });
+}

--- a/src/hooks/useProjectQualifs.ts
+++ b/src/hooks/useProjectQualifs.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { readItems } from "@directus/sdk";
+import { directus } from "@/lib/directus";
+import type { ProjectQualif } from "../../models/types";
+
+export function useProjectQualifs() {
+  return useQuery({
+    queryKey: ["project_qualifs"],
+    queryFn: () =>
+      directus.request<Pick<ProjectQualif, "id" | "label">[]>(
+        readItems("project_qualifs", { fields: ["id", "label"], sort: "label" }),
+      ),
+  });
+}

--- a/src/hooks/useSectors.ts
+++ b/src/hooks/useSectors.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { readItems } from "@directus/sdk";
+import { directus } from "@/lib/directus";
+import type { Sector } from "../../models/types";
+
+export function useSectors() {
+  return useQuery({
+    queryKey: ["sectors"],
+    queryFn: () =>
+      directus.request<Pick<Sector, "id" | "label">[]>(
+        readItems("sectors", { fields: ["id", "label"], sort: "label" }),
+      ),
+  });
+}


### PR DESCRIPTION
## Summary
- fetch sectors, origins, contact qualifications and project qualifications from Directus
- capture contact info when creating a contribution
- create contact then create contribution with new fields

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687f591f7e70832ca6e2a2a96f66e8b6