### PR TITLE
Implement archive contribution mutation

### DIFF
--- a/src/hooks/useArchiveContribution.ts
+++ b/src/hooks/useArchiveContribution.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { readItems, updateItem } from "@directus/sdk";
+import { directus } from "@/lib/directus";
+
+export function useArchiveContribution() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const statuses = await directus.request<{ id: string }[]>(
+        readItems("contributions_status", {
+          fields: ["id"],
+          filter: { label: { _eq: "ARCHIVED" } },
+          limit: 1,
+        }),
+      );
+      const statusId = statuses[0]?.id;
+      return directus.request(updateItem("contributions", id, { status: statusId }));
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["contributions"] });
+      queryClient.invalidateQueries({ queryKey: ["contribution"] });
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- add `useArchiveContribution` hook using React Query
- update `ContributionDrawer` to archive via mutation with notifications

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687f97091eac832c9c0b4484d213b977